### PR TITLE
Return an empty array of results rather than throw an exception if the Rest API returns nothing

### DIFF
--- a/lib/splunk-sdk-ruby/client.rb
+++ b/lib/splunk-sdk-ruby/client.rb
@@ -874,8 +874,13 @@ module Splunk
       args[:output_mode] = 'json'
       response = @service.context.post(PATH_JOBS, args)
 
-      json = JSON.parse(response)
-      SearchResults.new(json)
+      begin 
+        json = JSON.parse(response)
+        SearchResults.new(json)
+      rescue JSON::ParserError
+        SearchResults.new(Array.new)
+      end
+
     end
 
     # Run a <b>streamed search</b> .  Rather than returning an object that can take up a huge amount of memory by including


### PR DESCRIPTION
Splunk::Jobs.create_oneshot currently throws a JSON::ParserError if there are no results returned by the REST API.

This commit catches a JSON::ParserError and returns a SearchResult of an empty array for consistency. 
