### PR TITLE
Move dependencies from Gemfile into .gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,2 @@
 source :rubygems
-
-gem 'libxml-ruby', '~>2.2.2'
-gem 'json_pure', '~>1.6.4'
-gem 'json-stream', '~>0.1.2'
-gem 'netrc', '~>0.5'
-gem 'rest-client', '~>1.6.7'
-gem 'uuid', '~>2.3.4'
+gemspec

--- a/splunk-sdk-ruby.gemspec
+++ b/splunk-sdk-ruby.gemspec
@@ -15,4 +15,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Splunk::VERSION
   gem.required_ruby_version = '>=1.9.2'
+  gem.add_dependency 'libxml-ruby', '~>2.2.2'
+  gem.add_dependency 'json_pure', '~>1.6.4'
+  gem.add_dependency 'json-stream', '~>0.1.2'
+  gem.add_dependency 'netrc', '~>0.5'
+  gem.add_dependency 'rest-client', '~>1.6.7'
+  gem.add_dependency 'uuid', '~>2.3.4'
 end


### PR DESCRIPTION
Move dependencies into the gemspec file. Without this dependencies on libmxl-ruby, json_pure, json_stream, netrc, rest-client and uuid are not fulfilled when installing the gem.

The gemfile now references .gemspec to get it's list of dependencies from there instead.
