### PR TITLE
Remove runtime dependency on Test-Unit

### DIFF
--- a/splunk-sdk-ruby.gemspec
+++ b/splunk-sdk-ruby.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>=1.9.2'
   gem.add_dependency 'jruby-openssl', '~>0.7.7' if RUBY_PLATFORM == "java"
   gem.add_dependency 'rake', '~>10'
-  gem.add_dependency 'test-unit'
+  gem.add_development_dependency 'test-unit'
 
   gem.files         = Dir['{lib,examples,test}/**/*',
                           'CHANGELOG.md', 


### PR DESCRIPTION
When using the Splunk Ruby SDK together with Cucumber issues pop up in cucumber as the splunk sdk requires test-unit at runtime.
I don't the test-unit is needed at runtime.
