### PR TITLE
added support for HTTP Basic Authentication, bumped version

### DIFF
--- a/lib/splunk-sdk-ruby/context.rb
+++ b/lib/splunk-sdk-ruby/context.rb
@@ -63,6 +63,7 @@ module Splunk
   # * +:ssl_client_cert+ A +OpenSSL::X509::Certificate+ object to use as a client certificate.
   # * +:ssl_client_key+ A +OpenSSL::PKey::RSA+ or +OpenSSL::PKey::DSA+ object to use as a client key.
   # * +:token+ - a preauthenticated Splunk token (default: +nil+)
+  # * +:basic+ - indicates if HTTP Basic Auth is going to be used (default: +false+)
   #
   # If you specify a token, you need not specify a username or password, nor
   # do you need to call the +login+ method.

--- a/lib/splunk-sdk-ruby/context.rb
+++ b/lib/splunk-sdk-ruby/context.rb
@@ -87,6 +87,7 @@ module Splunk
       @namespace = args.fetch(:namespace,
                               Splunk::namespace(:sharing => "default"))
       @proxy = args.fetch(:proxy, nil)
+      @basic = args.fetch(:basic, nil)
       @path_prefix = args.fetch(:path_prefix, DEFAULT_PATH_PREFIX)
       @ssl_client_cert = args.fetch(:ssl_client_cert, nil)
       @ssl_client_key = args.fetch(:ssl_client_key, nil)
@@ -418,6 +419,10 @@ module Splunk
       # Headers
       request["User-Agent"] = "splunk-sdk-ruby/#{VERSION}"
       request["Authorization"] = "Splunk #{@token}" if @token
+      # basic authentication supercedes Splunk authentication
+      if @basic then
+        request["Authorization"] = "Basic " + ["#{@username}:#{@password}"].pack('m').strip
+      end
       headers.each_entry do |key, value|
         request[key] = value
       end

--- a/lib/splunk-sdk-ruby/context.rb
+++ b/lib/splunk-sdk-ruby/context.rb
@@ -87,7 +87,7 @@ module Splunk
       @namespace = args.fetch(:namespace,
                               Splunk::namespace(:sharing => "default"))
       @proxy = args.fetch(:proxy, nil)
-      @basic = args.fetch(:basic, nil)
+      @basic = args.fetch(:basic, False)
       @path_prefix = args.fetch(:path_prefix, DEFAULT_PATH_PREFIX)
       @ssl_client_cert = args.fetch(:ssl_client_cert, nil)
       @ssl_client_key = args.fetch(:ssl_client_key, nil)
@@ -226,7 +226,9 @@ module Splunk
       if @token # If we're already logged in, this method is a nop.
         return
       end
-
+      if @basic # We're using basic authentication, thus making this a nop
+        return
+      end
       response = request(:namespace => Splunk::namespace(:sharing => "default"),
                          :method => :POST,
                          :resource => ["auth", "login"],

--- a/lib/splunk-sdk-ruby/version.rb
+++ b/lib/splunk-sdk-ruby/version.rb
@@ -23,5 +23,5 @@
 # release new versions.
 #
 module Splunk
-  VERSION = '1.0.3'
+  VERSION = '1.0.4.1'
 end

--- a/lib/splunk-sdk-ruby/version.rb
+++ b/lib/splunk-sdk-ruby/version.rb
@@ -23,5 +23,5 @@
 # release new versions.
 #
 module Splunk
-  VERSION = '1.0.4.1'
+  VERSION = '1.0.3'
 end

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -57,6 +57,16 @@ class TestContext < TestCaseWithSplunkConnection
     assert_logged_in(new_service)
   end
 
+  def test_authenticate_with_basic
+    new_arguments = @splunkrc.clone
+    new_arguments.delete(:username)
+    new_arguments.delete(:password)
+    new_arguments[:basic] = True
+
+    new_service = Context.new(new_arguments)
+    assert_logged_in(new_service)
+  end
+
   def test_failed_login()
     args = @splunkrc.clone()
     args[:username] = args[:username] + "-boris"

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -65,6 +65,7 @@ class TestContext < TestCaseWithSplunkConnection
 
     new_service = Context.new(new_arguments)
     assert_logged_in(new_service)
+    assert_true(new_service.apps.length() > 0)
   end
 
   def test_failed_login()


### PR DESCRIPTION
added support for HTTP(S) Basic authentication. Basically, when creating a context configuration, if you specify basic, it will automatically generate the correct Authorization header, that will take the place of Spunk token authentication.

I have signed the contributor agreement. 

If you see something that you do not like in this PR, let me know and I will do my best to address your comments. As this is required for production use in the day job, I would really appreciate a fast response.